### PR TITLE
Fixes #4 by removing migration splitting since it breaks multiline SQL scripts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ For a given migration, the `id` and `name` fields must be the same.
 The id field is an integer that corresponds to the order in which
 the migration should run relative to the other migrations.
 
+`id` should not be `0` as that value is used for internal validations.
+
 ### Example
 
 If I'm trying to add a "users" table to the database, I would create

--- a/gomigrate_test.go
+++ b/gomigrate_test.go
@@ -43,10 +43,10 @@ func TestNewMigrator(t *testing.T) {
 		t.Errorf("Invalid migration name detected: %s", migration.Name)
 	}
 	if migration.Id != 1 {
-		t.Errorf("Invalid migration num detected: %s", migration.Id)
+		t.Errorf("Invalid migration num detected: %d", migration.Id)
 	}
 	if migration.Status != Inactive {
-		t.Errorf("Invalid migration num detected: %s", migration.Status)
+		t.Errorf("Invalid migration num detected: %d", migration.Status)
 	}
 
 	cleanup()

--- a/test_migrations/test1_pg/1_test_down.sql
+++ b/test_migrations/test1_pg/1_test_down.sql
@@ -1,1 +1,1 @@
-drop table test;
+drop table if exists test;

--- a/test_migrations/test1_pg/1_test_up.sql
+++ b/test_migrations/test1_pg/1_test_up.sql
@@ -1,1 +1,1 @@
-create table test();
+create table if not exists test();

--- a/test_migrations/test1_pg/2_create_index_function_if_not_exists_down.sql
+++ b/test_migrations/test1_pg/2_create_index_function_if_not_exists_down.sql
@@ -1,0 +1,1 @@
+drop function if exists create_index_if_not_exists (t_name text, i_name text, index_sql text);

--- a/test_migrations/test1_pg/2_create_index_function_if_not_exists_up.sql
+++ b/test_migrations/test1_pg/2_create_index_function_if_not_exists_up.sql
@@ -1,0 +1,23 @@
+-- this function allows us to create indexes if they don't exist
+create or replace function create_index_if_not_exists (t_name text, i_name text, index_sql text) returns void as $$
+declare
+  full_index_name varchar;
+  schema_name varchar;
+begin
+
+full_index_name = t_name || '_' || i_name;
+schema_name = 'public';
+
+if not exists (
+    select 1
+    from   pg_class c
+    join   pg_namespace n on n.oid = c.relnamespace
+    where  c.relname = full_index_name
+    and    n.nspname = schema_name
+    ) then
+
+    execute 'create index ' || full_index_name || ' on ' || schema_name || '.' || t_name || ' ' || index_sql;
+end if;
+end
+$$
+language plpgsql volatile;

--- a/utils.go
+++ b/utils.go
@@ -40,11 +40,6 @@ func parseMatches(matches [][][]byte, mType migrationType) (uint64, migrationTyp
 	return parsedNum, mType, string(name), nil
 }
 
-// Splits migration sql into different strings separated by a semi-colon.
-func splitMigrationString(sql string) []string {
-	return subMigrationSplit.Split(sql, -1)
-}
-
 // This type is used to sort migration ids.
 type uint64slice []uint64
 


### PR DESCRIPTION
Fixes #4 and it also adds clarification in documentation regarding migration identifiers.