### PR TITLE
Isolate migrations table check to a given schema instead of server-wide

### DIFF
--- a/db.go
+++ b/db.go
@@ -40,7 +40,7 @@ func (p Postgres) MigrationLogDeleteSql() string {
 type Mysql struct{}
 
 func (m Mysql) SelectMigrationTableSql() string {
-	return "SELECT table_name FROM information_schema.tables WHERE table_name = ?"
+	return "SELECT table_name FROM information_schema.tables WHERE table_name = ? AND table_schema = (SELECT DATABASE())"
 }
 
 func (m Mysql) CreateMigrationTableSql() string {


### PR DESCRIPTION
As-is, testing for the existence of the gomigrate migrations table isn't isolated to a given schema, and is instead scoped server-wide.  This presents a problem when there are multiple database schemas on a given server, all being managed via gomigrate, as the 'table exists' test will succeed, but the migration will fail because the migrations table doesn't actually exist in the target schema.

This PR isolates the migrations table existence check to the given schema, thus offering the ability to use gomigrate for schema management for multiple schemas under a given server.