### PR TITLE
Added support for migrations with comments (mysql only)

### DIFF
--- a/test_migrations/test1_mysql/1_test_up.sql
+++ b/test_migrations/test1_mysql/1_test_up.sql
@@ -3,10 +3,14 @@ CREATE TABLE test (
      PRIMARY KEY (id)
 );
 
+SELECT 'my comment' AS comment;
+
 CREATE TABLE test2 (
      id INT NOT NULL AUTO_INCREMENT,
      PRIMARY KEY (id)
 );
+
+SELECT 'my other comment' AS comment;
 
 CREATE TABLE tt (c text NOT NULL);
 


### PR DESCRIPTION
I wanted a way for gomigrate to print out comments/status inside a migration. This only applies for mysql, since it's the only supported db type with multi-command migrations.